### PR TITLE
fixed a small bug of "Server Error - TypeError: t.default.createContext is not a function" in Approach component.

### DIFF
--- a/components/Approach.tsx
+++ b/components/Approach.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from "react";
 import { AnimatePresence, motion } from "framer-motion";
 


### PR DESCRIPTION
I don't if you faced this issue or not but in the Approach component we are using animations from framer motion which requires client side rendering but the component is by default server side rendered and i got this issue "Server Error - TypeError: t.default.createContext is not a function ". When I used 'use client' on the top of  the component then it no longer gave me the error. I hope this helps.