### PR TITLE
fix: footer background bottom, project navigation link

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,7 +7,7 @@ const Footer = () => {
   return (
     <footer className="w-full pt-20 pb-10" id="contact">
       {/* background grid */}
-      <div className="w-full absolute left-0 -bottom-72 min-h-96">
+      <div className="w-full absolute left-0 bottom-0 min-h-96">
         <img
           src="/footer-grid.svg"
           alt="grid"

--- a/components/RecentProjects.tsx
+++ b/components/RecentProjects.tsx
@@ -7,7 +7,7 @@ import { PinContainer } from "./ui/Pin";
 
 const RecentProjects = () => {
   return (
-    <div className="py-20">
+    <div className="py-20" id="projects">
       <h1 className="heading">
         A small selection of{" "}
         <span className="text-purple">recent projects</span>


### PR DESCRIPTION
For detailed information and conversation about the error, refer to the following link https://discord.com/channels/710138849350647871/1266947816375320587

1. Floating Navbar (projects) is not redirecting correctly.
2. When pressing the navbar menu and then scrolling up, the title of the hero section is messed up and has a bad top margin